### PR TITLE
Implement the database connection and fetch announcements on request

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,1 @@
+MONGODB_URI=mongodb+srv://user:pass@domain/db?retryWrites=true&w=majority

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ The site for the Andy-Fin 22-23 Sophomore caucus.
 
 **Hosting:** Vercel
 
+## Environment Variables
+
+To run this project, you will need to add the following environment variables to your .env file
+
+`MONGODB_URI`
+
 ## Run Locally
 
 Clone the project
@@ -49,10 +55,6 @@ Run the production server
 ```bash
 npm start
 ```
-
-## Environment Variables
-
-None!
 
 ## Authors
 

--- a/lib/dbConnect.ts
+++ b/lib/dbConnect.ts
@@ -1,0 +1,50 @@
+// /lib/dbConnect.js
+import mongoose from "mongoose";
+
+/**
+Source: https://github.com/vercel/next.js/blob/canary/examples/with-mongodb-mongoose/utils/dbConnect.js 
+**/
+
+const MONGODB_URI = process.env.MONGODB_URI || "";
+
+if (!MONGODB_URI) {
+	throw new Error(
+		"Please define the MONGODB_URI environment variable inside .env.local"
+	);
+}
+
+/**
+ * Global is used here to maintain a cached connection across hot reloads
+ * in development. This prevents connections growing exponentially
+ * during API Route usage.
+ */
+
+let cached = global.mongoose;
+
+if (!cached) {
+	cached = global.mongoose = { conn: null, promise: null };
+}
+
+async function dbConnect() {
+	if (cached.conn) {
+		return cached.conn;
+	}
+
+	if (!cached.promise) {
+		const opts = {
+			useNewUrlParser: true,
+			useUnifiedTopology: true,
+			bufferCommands: false,
+		};
+
+		cached.promise = mongoose
+			.connect(MONGODB_URI as string, opts)
+			.then((mongoose: any) => {
+				return mongoose;
+			});
+	}
+	cached.conn = await cached.promise;
+	return cached.conn;
+}
+
+export default dbConnect;

--- a/lib/getServerUrl.ts
+++ b/lib/getServerUrl.ts
@@ -1,7 +1,7 @@
 function getServerUrl() {
 	const dev = process.env.NODE_ENV !== "production";
 
-	return dev ? "http://localhost:3000" : "https://sophomore.stuysu.org";
+	return dev ? "http://localhost:3000" : process.env.VERCEL_URL;
 }
 
 export default getServerUrl;

--- a/lib/getServerUrl.ts
+++ b/lib/getServerUrl.ts
@@ -1,7 +1,7 @@
 function getServerUrl() {
 	const dev = process.env.NODE_ENV !== "production";
 
-	return dev ? "http://localhost:3000" : process.env.VERCEL_URL;
+	return dev ? "http://localhost:3000" : process.env.NEXT_PUBLIC_VERCEL_URL;
 }
 
 export default getServerUrl;

--- a/lib/getServerUrl.ts
+++ b/lib/getServerUrl.ts
@@ -1,0 +1,7 @@
+function getServerUrl() {
+	const dev = process.env.NODE_ENV !== "production";
+
+	return dev ? "http://localhost:3000" : "https://sophomore.stuysu.org";
+}
+
+export default getServerUrl;

--- a/lib/getServerUrl.ts
+++ b/lib/getServerUrl.ts
@@ -1,7 +1,9 @@
 function getServerUrl() {
 	const dev = process.env.NODE_ENV !== "production";
 
-	return dev ? "http://localhost:3000" : process.env.NEXT_PUBLIC_VERCEL_URL;
+	return dev
+		? "http://localhost:3000"
+		: "https://" + process.env.NEXT_PUBLIC_VERCEL_URL;
 }
 
 export default getServerUrl;

--- a/models/Announcement.ts
+++ b/models/Announcement.ts
@@ -1,0 +1,8 @@
+import mongoose from "mongoose";
+
+const AnnouncementSchema = new mongoose.Schema({
+	title: String,
+});
+
+export default mongoose.models.Announcement ||
+	mongoose.model("announcement", AnnouncementSchema);

--- a/models/Announcement.ts
+++ b/models/Announcement.ts
@@ -3,6 +3,8 @@ import mongoose from "mongoose";
 const AnnouncementSchema = new mongoose.Schema({
 	title: String,
 });
+const AnnouncementModel =
+	mongoose.models.Announcement ||
+	mongoose.model("Announcement", AnnouncementSchema);
 
-export default mongoose.models.Announcement ||
-	mongoose.model("announcement", AnnouncementSchema);
+export default AnnouncementModel;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "sophomore.stuysu.org",
 			"version": "0.1.0",
 			"dependencies": {
+				"mongoose": "^6.5.1",
 				"next": "12.2.4",
 				"react": "18.2.0",
 				"react-dom": "18.2.0",
@@ -364,8 +365,7 @@
 		"node_modules/@types/node": {
 			"version": "18.6.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-			"integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
-			"dev": true
+			"integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg=="
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.5",
@@ -398,6 +398,20 @@
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
 			"dev": true
+		},
+		"node_modules/@types/webidl-conversions": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+			"integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+		},
+		"node_modules/@types/whatwg-url": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+			"integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/webidl-conversions": "*"
+			}
 		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "5.32.0",
@@ -671,6 +685,25 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -691,6 +724,40 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/bson": {
+			"version": "4.6.5",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+			"integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
+			"dependencies": {
+				"buffer": "^5.6.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"node_modules/call-bind": {
@@ -811,7 +878,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -844,6 +910,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/denque": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1779,6 +1853,25 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/ignore": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -1842,6 +1935,11 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/ip": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
 		},
 		"node_modules/is-bigint": {
 			"version": "1.0.4",
@@ -2097,6 +2195,11 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/kareem": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.4.1.tgz",
+			"integrity": "sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA=="
+		},
 		"node_modules/language-subtag-registry": {
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -2169,6 +2272,12 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/memory-pager": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"optional": true
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2209,11 +2318,81 @@
 			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
+		"node_modules/mongodb": {
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.1.tgz",
+			"integrity": "sha512-/NyiM3Ox9AwP5zrfT9TXjRKDJbXlLaUDQ9Rg//2lbg8D2A8GXV0VidYYnA/gfdK6uwbnL4FnAflH7FbGw3TS7w==",
+			"dependencies": {
+				"bson": "^4.6.5",
+				"denque": "^2.0.1",
+				"mongodb-connection-string-url": "^2.5.2",
+				"socks": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=12.9.0"
+			},
+			"optionalDependencies": {
+				"saslprep": "^1.0.3"
+			}
+		},
+		"node_modules/mongodb-connection-string-url": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+			"integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+			"dependencies": {
+				"@types/whatwg-url": "^8.2.1",
+				"whatwg-url": "^11.0.0"
+			}
+		},
+		"node_modules/mongoose": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.5.1.tgz",
+			"integrity": "sha512-8C0213y279nrSp6Au+WB+l/VczcotMU65jalTJJxU6KYf/Kd8gNW9+B3giWNJOVd8VvKvUQG0suWv/Vngp/83A==",
+			"dependencies": {
+				"bson": "^4.6.5",
+				"kareem": "2.4.1",
+				"mongodb": "4.8.1",
+				"mpath": "0.9.0",
+				"mquery": "4.0.3",
+				"ms": "2.1.3",
+				"sift": "16.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mongoose"
+			}
+		},
+		"node_modules/mongoose/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"node_modules/mpath": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+			"integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/mquery": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+			"integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+			"dependencies": {
+				"debug": "4.x"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.4",
@@ -2573,7 +2752,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2744,6 +2922,18 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/saslprep": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"optional": true,
+			"dependencies": {
+				"sparse-bitfield": "^3.0.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/scheduler": {
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -2802,6 +2992,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/sift": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
+			"integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ=="
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2811,12 +3006,43 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+			"integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+			"dependencies": {
+				"ip": "^2.0.0",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0",
+				"npm": ">= 3.0.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sparse-bitfield": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+			"integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+			"optional": true,
+			"dependencies": {
+				"memory-pager": "^1.0.2"
 			}
 		},
 		"node_modules/string.prototype.matchall": {
@@ -2960,6 +3186,17 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+			"dependencies": {
+				"punycode": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/tsconfig-paths": {
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -3072,6 +3309,26 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+			"dependencies": {
+				"tr46": "^3.0.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -3339,8 +3596,7 @@
 		"@types/node": {
 			"version": "18.6.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-			"integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
-			"dev": true
+			"integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg=="
 		},
 		"@types/prop-types": {
 			"version": "15.7.5",
@@ -3373,6 +3629,20 @@
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
 			"dev": true
+		},
+		"@types/webidl-conversions": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+			"integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+		},
+		"@types/whatwg-url": {
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+			"integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+			"requires": {
+				"@types/node": "*",
+				"@types/webidl-conversions": "*"
+			}
 		},
 		"@typescript-eslint/parser": {
 			"version": "5.32.0",
@@ -3550,6 +3820,11 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3567,6 +3842,23 @@
 			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
+			}
+		},
+		"bson": {
+			"version": "4.6.5",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.5.tgz",
+			"integrity": "sha512-uqrgcjyOaZsHfz7ea8zLRCLe1u+QGUSzMZmvXqO24CDW7DWoW1qiN9folSwa7hSneTSgM2ykDIzF5kcQQ8cwNw==",
+			"requires": {
+				"buffer": "^5.6.0"
+			}
+		},
+		"buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
 			}
 		},
 		"call-bind": {
@@ -3654,7 +3946,6 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -3674,6 +3965,11 @@
 				"has-property-descriptors": "^1.0.0",
 				"object-keys": "^1.1.1"
 			}
+		},
+		"denque": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -4390,6 +4686,11 @@
 				"has-symbols": "^1.0.2"
 			}
 		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+		},
 		"ignore": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -4438,6 +4739,11 @@
 				"has": "^1.0.3",
 				"side-channel": "^1.0.4"
 			}
+		},
+		"ip": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
 		},
 		"is-bigint": {
 			"version": "1.0.4",
@@ -4615,6 +4921,11 @@
 				"object.assign": "^4.1.2"
 			}
 		},
+		"kareem": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.4.1.tgz",
+			"integrity": "sha512-aJ9opVoXroQUPfovYP5kaj2lM7Jn02Gw13bL0lg9v0V7SaUc0qavPs0Eue7d2DcC3NjqI6QAUElXNsuZSeM+EA=="
+		},
 		"language-subtag-registry": {
 			"version": "0.3.22",
 			"resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz",
@@ -4672,6 +4983,12 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"memory-pager": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"optional": true
+		},
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4703,11 +5020,65 @@
 			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
+		"mongodb": {
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.8.1.tgz",
+			"integrity": "sha512-/NyiM3Ox9AwP5zrfT9TXjRKDJbXlLaUDQ9Rg//2lbg8D2A8GXV0VidYYnA/gfdK6uwbnL4FnAflH7FbGw3TS7w==",
+			"requires": {
+				"bson": "^4.6.5",
+				"denque": "^2.0.1",
+				"mongodb-connection-string-url": "^2.5.2",
+				"saslprep": "^1.0.3",
+				"socks": "^2.6.2"
+			}
+		},
+		"mongodb-connection-string-url": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+			"integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+			"requires": {
+				"@types/whatwg-url": "^8.2.1",
+				"whatwg-url": "^11.0.0"
+			}
+		},
+		"mongoose": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.5.1.tgz",
+			"integrity": "sha512-8C0213y279nrSp6Au+WB+l/VczcotMU65jalTJJxU6KYf/Kd8gNW9+B3giWNJOVd8VvKvUQG0suWv/Vngp/83A==",
+			"requires": {
+				"bson": "^4.6.5",
+				"kareem": "2.4.1",
+				"mongodb": "4.8.1",
+				"mpath": "0.9.0",
+				"mquery": "4.0.3",
+				"ms": "2.1.3",
+				"sift": "16.0.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+				}
+			}
+		},
+		"mpath": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+			"integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
+		},
+		"mquery": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+			"integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+			"requires": {
+				"debug": "4.x"
+			}
+		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"nanoid": {
 			"version": "3.3.4",
@@ -4946,8 +5317,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"queue-microtask": {
 			"version": "1.2.3",
@@ -5048,6 +5418,15 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"saslprep": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"optional": true,
+			"requires": {
+				"sparse-bitfield": "^3.0.3"
+			}
+		},
 		"scheduler": {
 			"version": "0.23.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -5091,16 +5470,44 @@
 				"object-inspect": "^1.9.0"
 			}
 		},
+		"sift": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
+			"integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ=="
+		},
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
+		"smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+		},
+		"socks": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+			"integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+			"requires": {
+				"ip": "^2.0.0",
+				"smart-buffer": "^4.2.0"
+			}
+		},
 		"source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+		},
+		"sparse-bitfield": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+			"integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+			"optional": true,
+			"requires": {
+				"memory-pager": "^1.0.2"
+			}
 		},
 		"string.prototype.matchall": {
 			"version": "4.0.7",
@@ -5197,6 +5604,14 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"tr46": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+			"requires": {
+				"punycode": "^2.1.1"
+			}
+		},
 		"tsconfig-paths": {
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5284,6 +5699,20 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
+		},
+		"webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+		},
+		"whatwg-url": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+			"requires": {
+				"tr46": "^3.0.0",
+				"webidl-conversions": "^7.0.0"
+			}
 		},
 		"which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"lint": "next lint"
 	},
 	"dependencies": {
+		"mongoose": "^6.5.1",
 		"next": "12.2.4",
 		"react": "18.2.0",
 		"react-dom": "18.2.0",

--- a/pages/api/get_announcements.ts
+++ b/pages/api/get_announcements.ts
@@ -25,6 +25,7 @@ export default async function handler(
 
 				res.status(200).json({ success: true, data: announcements });
 			} catch (error) {
+				console.error(error);
 				res.status(400).json({ success: false });
 			}
 			break;

--- a/pages/api/get_announcements.ts
+++ b/pages/api/get_announcements.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import dbConnect from "../../lib/dbConnect";
 import Announcement from "../../models/Announcement";
 import { ReceivedAnnouncement } from "../../types/db_types";
+import { Types } from "mongoose";
 
 type ReponseData = {
 	success: boolean;
@@ -19,9 +20,17 @@ export default async function handler(
 	switch (method) {
 		case "GET":
 			try {
-				const announcements = (await Announcement.find(
-					{}
-				)) as ReceivedAnnouncement[];
+				let db_announcements = (await Announcement.find({})) as any[];
+
+				let announcements = db_announcements.map((v) => {
+					const objid = new Types.ObjectId(v._id);
+					const rdate = objid.getTimestamp();
+
+					let newv = v.toObject();
+					newv.date = rdate;
+
+					return newv;
+				}) as ReceivedAnnouncement[];
 
 				res.status(200).json({ success: true, data: announcements });
 			} catch (error) {

--- a/pages/api/get_announcements.ts
+++ b/pages/api/get_announcements.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import dbConnect from "../../lib/dbConnect";
+import Announcement from "../../models/Announcement";
+import { ReceivedAnnouncement } from "../../types/db_types";
+
+type ReponseData = {
+	success: boolean;
+	data?: ReceivedAnnouncement | ReceivedAnnouncement[];
+};
+
+export default async function handler(
+	req: NextApiRequest,
+	res: NextApiResponse<ReponseData>
+) {
+	const { method } = req;
+
+	await dbConnect();
+
+	switch (method) {
+		case "GET":
+			try {
+				const announcements = (await Announcement.find(
+					{}
+				)) as ReceivedAnnouncement[];
+
+				res.status(200).json({ success: true, data: announcements });
+			} catch (error) {
+				res.status(400).json({ success: false });
+			}
+			break;
+		// case "POST":
+		// 	try {
+		// 		const announcement = (await Announcement.create(
+		// 			req.body
+		// 		)) as ReceivedAnnouncement;
+		// 		res.status(201).json({ success: true, data: announcement });
+		// 	} catch (error) {
+		// 		res.status(400).json({ success: false });
+		// 	}
+		// 	break;
+		default:
+			res.status(400).json({ success: false });
+			break;
+	}
+}

--- a/pages/api/get_announcements.ts
+++ b/pages/api/get_announcements.ts
@@ -38,16 +38,6 @@ export default async function handler(
 				res.status(400).json({ success: false });
 			}
 			break;
-		// case "POST":
-		// 	try {
-		// 		const announcement = (await Announcement.create(
-		// 			req.body
-		// 		)) as ReceivedAnnouncement;
-		// 		res.status(201).json({ success: true, data: announcement });
-		// 	} catch (error) {
-		// 		res.status(400).json({ success: false });
-		// 	}
-		// 	break;
 		default:
 			res.status(400).json({ success: false });
 			break;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,7 +13,9 @@ import { Key } from "react";
 const Home = (
 	props: InferGetServerSidePropsType<typeof getServerSideProps>
 ) => {
-	console.log("Props : ", props.announcements);
+	const parseDate = function (d: string) {
+		return new Date(d).toLocaleString().split(",")[0];
+	};
 	return (
 		<>
 			<Head>
@@ -45,7 +47,7 @@ const Home = (
 						<Announcement
 							key={v._id as Key}
 							text={v.title}
-							date={"6/9"}
+							date={parseDate(String(v.date))}
 						/>
 					))}
 				</section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,19 @@
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext } from "next";
 import Head from "next/head";
-import Image from "next/image";
 import styles from "../styles/Home.module.css";
 import Announcement from "../components/Announcement";
 import ScheduleWidget from "../components/ScheduleWidget";
 import BellSchedule from "../components/BellSchedule";
 import WeeklySchedule from "../components/WeeklySchedule";
+import { ReceivedAnnouncement } from "../types/db_types";
+import getServerUrl from "../lib/getServerUrl";
+import { InferGetServerSidePropsType } from "next";
+import { Key } from "react";
 
-const Home: NextPage = () => {
+const Home = (
+	props: InferGetServerSidePropsType<typeof getServerSideProps>
+) => {
+	console.log("Props : ", props.announcements);
 	return (
 		<>
 			<Head>
@@ -35,29 +41,30 @@ const Home: NextPage = () => {
 					</div>
 				</section>
 				<section id={styles.announcements}>
-					<Announcement
-						text={"This program is brought to you by"}
-						date={"6/9"}
-					/>
-					<Announcement
-						text={"contributions to your local PBS station"}
-						date={"6/9"}
-					/>
-					<Announcement
-						text={"by viewers like you, thank you!"}
-						date={"6/9"}
-					/>
-					<Announcement text={"test"} date={"6/9"} />
-					<Announcement text={"one two three four"} date={"6/9"} />
-					<Announcement
-						text={"Lorem ipsum something idk"}
-						date={"12/24"}
-					/>
-					<Announcement text={"Something something"} date={"2/22"} />
+					{props.announcements.map((v) => (
+						<Announcement
+							key={v._id as Key}
+							text={v.title}
+							date={"6/9"}
+						/>
+					))}
 				</section>
 			</main>
 		</>
 	);
+};
+
+type getAnnouncementsResponse = {
+	success: boolean;
+	data: ReceivedAnnouncement[];
+};
+
+export const getServerSideProps = async (
+	context: GetServerSidePropsContext
+) => {
+	const r: any = await fetch(getServerUrl() + "/api/get_announcements");
+	const data: getAnnouncementsResponse = await r.json();
+	return { props: { announcements: data.data } };
 };
 
 export default Home;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -16,6 +16,7 @@ const Home = (
 	const parseDate = function (d: string) {
 		return new Date(d).toLocaleString().split(",")[0];
 	};
+	console.log("Server url", props.serverUrl);
 	return (
 		<>
 			<Head>
@@ -59,6 +60,7 @@ const Home = (
 type getAnnouncementsResponse = {
 	success: boolean;
 	data: ReceivedAnnouncement[];
+	serverUrl: string;
 };
 
 export const getServerSideProps = async (
@@ -66,7 +68,7 @@ export const getServerSideProps = async (
 ) => {
 	const r: any = await fetch(getServerUrl() + "/api/get_announcements");
 	const data: getAnnouncementsResponse = await r.json();
-	return { props: { announcements: data.data } };
+	return { props: { announcements: data.data, serverUrl: getServerUrl() } };
 };
 
 export default Home;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
 		"jsx": "preserve",
 		"incremental": true
 	},
-	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+	"include": ["next-env.d.ts", "utils/global.d.ts", "**/*.ts", "**/*.tsx"],
 	"exclude": ["node_modules"]
 }

--- a/types/db_types.ts
+++ b/types/db_types.ts
@@ -4,4 +4,5 @@ export type mongoObjectId = Types.ObjectId | string;
 export interface ReceivedAnnouncement {
 	_id: mongoObjectId;
 	title: string;
+	date: Date | string;
 }

--- a/types/db_types.ts
+++ b/types/db_types.ts
@@ -1,0 +1,7 @@
+import { Types } from "mongoose";
+
+export type mongoObjectId = Types.ObjectId | string;
+export interface ReceivedAnnouncement {
+	_id: mongoObjectId;
+	title: string;
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,9 @@
+import { Connection } from "mongoose";
+
+declare global {
+	var mongoose: any;
+}
+
+export const mongoose = global.mongoose || new Connection();
+
+if (process.env.NODE_ENV !== "production") global.mongoose = mongoose;


### PR DESCRIPTION
Create the /api/get_announcements route (that caches the mongodb connection so that connections are not created for every request)

Also, the mongoDB connection (in the global namespace declaration) has proper types (added in global.d.ts) 

Add type support for the ReceievedAnnouncement


On every request to / (the homepage), request the /api/get_announcements route and fetch the latest announcements (implemented through getServerSideProps)

For this request, the server that is pinged will dynamically switch from either using the development localhost server or the URL that Vercel assigns its server (whatever that may be, production, development, or preview)