### PR TITLE
Add dynamic functionality to the schedule widget.

### DIFF
--- a/components/ScheduleWidget.tsx
+++ b/components/ScheduleWidget.tsx
@@ -1,11 +1,35 @@
 import styles from "../styles/ScheduleWidget.module.css";
 import { GradientPill, GradientShadow } from "./Gradient";
 import { ReceivedSchedule } from "../types/db_types";
+import { useEffect, useState } from "react";
+
+function timeToSeconds(time: string) {
+	let [shours, sminutes, sseconds, half] = time.split(/[\:\ ]/);
+	let hours = Number(shours);
+	let minutes = Number(sminutes);
+	let seconds = Number(sseconds);
+
+	if (half == "PM" && Number(hours) != 12) {
+		hours = Number(hours) + 12;
+	}
+	seconds = Number(seconds) + Number(minutes) * 60 + Number(hours) * 3600;
+	return seconds;
+}
 
 const ScheduleWidget = (props: {
 	current_schedule: ReceivedSchedule;
 	current_schedule_name: string;
 }) => {
+	useEffect(() => {
+		const id = setInterval(() => {
+			const ctime = new Date();
+			const locale_time_string = ctime.toLocaleTimeString("en-US");
+			const current_seconds = timeToSeconds(locale_time_string);
+
+			console.log("Current seconds", current_seconds);
+		}, 1000);
+		return () => clearInterval(id);
+	}, []);
 	return (
 		<div id={styles.container}>
 			<GradientPill

--- a/components/ScheduleWidget.tsx
+++ b/components/ScheduleWidget.tsx
@@ -13,6 +13,8 @@ interface TimeState {
 	locale_time_string: string;
 	seconds: number;
 	period_index: number;
+	units_elapsed: TimeUnits;
+	units_remaining: TimeUnits;
 }
 
 function timeToSeconds(time: string) {
@@ -79,11 +81,26 @@ const ScheduleWidget = (props: {
 				props.current_schedule
 			);
 
+			const seconds_elapsed =
+				current_seconds -
+				timeToSeconds(
+					props.current_schedule.segments[period_index].start
+				);
+			const seconds_remaining =
+				timeToSeconds(
+					props.current_schedule.segments[period_index].end
+				) - current_seconds;
+
+			const units_elapsed = secondsToUnits(seconds_elapsed);
+			const units_remaining = secondsToUnits(seconds_remaining);
+
 			setallTimeInfo({
 				units: current_units,
 				locale_time_string: locale_time_string,
 				seconds: current_seconds,
 				period_index: period_index,
+				units_elapsed: units_elapsed,
+				units_remaining: units_remaining,
 			});
 		}, 1000);
 		return () => clearInterval(id);
@@ -103,9 +120,22 @@ const ScheduleWidget = (props: {
 			<GradientShadow id={styles.schedule_widget}>
 				<div className={styles.bottom}>
 					<p>
-						<span className={styles.highlight}>14</span> min
-						<span className={styles.shorten_utes}>utes</span>
-						&nbsp;passed
+						{allTimeInfo?.units_elapsed.hours ? (
+							<>
+								<span className={styles.highlight}>
+									{allTimeInfo.units_elapsed.hours}
+								</span>
+								h{" "}
+							</>
+						) : (
+							<></>
+						)}
+						<span className={styles.highlight}>
+							{allTimeInfo
+								? allTimeInfo.units_elapsed.minutes
+								: "XX"}
+						</span>
+						m passed
 					</p>
 				</div>
 				<h1 id={styles.current_period}>
@@ -117,9 +147,22 @@ const ScheduleWidget = (props: {
 				</h1>
 				<div className={styles.bottom}>
 					<p>
-						<span className={styles.highlight}>36</span> min
-						<span className={styles.shorten_utes}>utes</span>
-						&nbsp;left
+						{allTimeInfo?.units_remaining.hours ? (
+							<>
+								<span className={styles.highlight}>
+									{allTimeInfo.units_remaining.hours}
+								</span>
+								h{" "}
+							</>
+						) : (
+							<></>
+						)}
+						<span className={styles.highlight}>
+							{allTimeInfo
+								? allTimeInfo.units_remaining.minutes
+								: "XX"}
+						</span>
+						m left
 					</p>
 				</div>
 			</GradientShadow>

--- a/components/ScheduleWidget.tsx
+++ b/components/ScheduleWidget.tsx
@@ -3,30 +3,78 @@ import { GradientPill, GradientShadow } from "./Gradient";
 import { ReceivedSchedule } from "../types/db_types";
 import { useEffect, useState } from "react";
 
+interface TimeUnits {
+	hours: number;
+	minutes: number;
+	seconds: number;
+}
+
 function timeToSeconds(time: string) {
 	let [shours, sminutes, sseconds, half] = time.split(/[\:\ ]/);
 	let hours = Number(shours);
+
+	if (half == "PM" && hours != 12) {
+		hours = Number(hours) + 12;
+	} else if (half == "AM" && hours == 12) {
+		hours = 0;
+	}
+
 	let minutes = Number(sminutes);
 	let seconds = Number(sseconds);
 
-	if (half == "PM" && Number(hours) != 12) {
-		hours = Number(hours) + 12;
-	}
 	seconds = Number(seconds) + Number(minutes) * 60 + Number(hours) * 3600;
 	return seconds;
+}
+
+function secondsToUnits(s: number): TimeUnits {
+	const hours = Math.floor(s / 3600);
+	let left = Number(s % 3600);
+	const minutes = Math.floor(left / 60);
+	const seconds = left % 60;
+	return { hours, minutes, seconds };
+}
+
+function getCurrentTimeInLocaleTimeString() {
+	const ctime = new Date();
+	const locale_time_string = ctime.toLocaleTimeString("en-US", {
+		timeZone: "US/Eastern", // Use the current time in NYC (Stuy)
+	});
+	return locale_time_string;
+}
+
+function getCurrentTimeInUnits() {
+	const locale_time_string = getCurrentTimeInLocaleTimeString();
+	const current_seconds = timeToSeconds(locale_time_string);
+
+	return secondsToUnits(current_seconds);
+}
+
+function formatTimeUnits(units: TimeUnits): string {
+	const filler_date = new Date(
+		2018,
+		11,
+		24,
+		units.hours,
+		units.minutes,
+		units.seconds,
+		0
+	);
+
+	return filler_date.toLocaleTimeString("en-US", {
+		timeZone: "UTC", // Timezone UTC because the units are already in EST time
+	});
 }
 
 const ScheduleWidget = (props: {
 	current_schedule: ReceivedSchedule;
 	current_schedule_name: string;
 }) => {
+	const [units, setUnits] = useState<TimeUnits>();
+
 	useEffect(() => {
 		const id = setInterval(() => {
-			const ctime = new Date();
-			const locale_time_string = ctime.toLocaleTimeString("en-US");
-			const current_seconds = timeToSeconds(locale_time_string);
-
-			console.log("Current seconds", current_seconds);
+			const current_units = getCurrentTimeInUnits();
+			setUnits(current_units);
 		}, 1000);
 		return () => clearInterval(id);
 	}, []);
@@ -36,7 +84,10 @@ const ScheduleWidget = (props: {
 				title={props.current_schedule_name}
 				id={styles.schedule_type}
 			/>
-			<GradientPill title="12:23 PM" id={styles.current_time} />
+			<GradientPill
+				title={units ? formatTimeUnits(units) : "XX:XX:XX PM"}
+				id={styles.current_time}
+			/>
 			<GradientShadow id={styles.schedule_widget}>
 				<div className={styles.bottom}>
 					<p>

--- a/styles/ScheduleWidget.module.css
+++ b/styles/ScheduleWidget.module.css
@@ -54,3 +54,9 @@
 		display: none;
 	}
 }
+
+@media (max-width: 480px) {
+	#current_period {
+		font-size: 2.75rem;
+	}
+}


### PR DESCRIPTION
Add dynamic functionality to the schedule widget on the homepage.

The current time, current period, time elapsed, and time remaining are all displayed.

The information is calculated client side, once per second.

All calculations, math, and operations are done in Vanilla JS, without any external (bloated) date-time processing libraries.