### PR TITLE
Make elapsed/remaining estimates add up

### DIFF
--- a/components/ScheduleWidget.tsx
+++ b/components/ScheduleWidget.tsx
@@ -81,7 +81,7 @@ const ScheduleWidget = (props: {
 						)}
 						<span className={styles.highlight}>
 							{allTimeInfo
-								? allTimeInfo.elapsed.getMinutes()
+								? allTimeInfo.elapsed.getMinutes() + Math.round(allTimeInfo.elapsed.getSeconds() / 60)
 								: "XX"}
 						</span>
 						m passed
@@ -108,7 +108,7 @@ const ScheduleWidget = (props: {
 						)}
 						<span className={styles.highlight}>
 							{allTimeInfo
-								? allTimeInfo.remaining.getMinutes()
+								? allTimeInfo.remaining.getMinutes() + Math.round(allTimeInfo.remaining.getSeconds() / 60)
 								: "XX"}
 						</span>
 						m left

--- a/components/ScheduleWidget.tsx
+++ b/components/ScheduleWidget.tsx
@@ -2,7 +2,7 @@ import styles from "../styles/ScheduleWidget.module.css";
 import { GradientPillCore, GradientShadow } from "./Gradient";
 import { useEffect, useState } from "react";
 import {
-	curSeconds,
+	datetimeToSeconds,
 	get_current_period,
 	ParsedPeriod,
 	secondsToTime, toStuyTimeString,
@@ -24,10 +24,10 @@ const ScheduleWidget = (props: {
 
 	useEffect(() => {
 		const id = setInterval(() => {
-			const locale_time_string = toStuyTimeString(new Date(), "medium");
-			const current_seconds = curSeconds();
-
-			const period_index = get_current_period(props.parsed_schedule);
+			const time = new Date();  // single source of truth
+			const locale_time_string = toStuyTimeString(time, "medium");
+			const current_seconds = datetimeToSeconds(time);
+			const period_index = get_current_period(props.parsed_schedule, current_seconds);
 
 			const elapsed = secondsToTime(
 				current_seconds - props.parsed_schedule[period_index].startSeconds

--- a/lib/periodHelpers.ts
+++ b/lib/periodHelpers.ts
@@ -12,21 +12,15 @@ export interface ParsedPeriod {
 }
 
 
-function datetimeToSeconds(date: Date): number {
-    return date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
-}
-
-export function curSeconds(): number {
-    const date = new Date();
+export function datetimeToSeconds(date: Date): number {
     return date.getHours() * 3600 + date.getMinutes() * 60 + date.getSeconds();
 }
 export function get_current_period (
-    schedule: ParsedPeriod[]
+    schedule: ParsedPeriod[],
+    curTime: Number = datetimeToSeconds(new Date())
 ): number {
-    const now = datetimeToSeconds(new Date());
-
     for (let i = 0; i < schedule.length; i++) {
-        if (now < schedule[i].endSeconds) {
+        if (curTime < schedule[i].endSeconds) {
             return i;
         }
     }


### PR DESCRIPTION
It always bothered me whenever I was staring at the site at the end of a period (I showed it to my Mandarin teacher and she began to use it as a test timer during class :sob:) that it would show "0 minutes" for so long, and that it would cap at 40 minutes not 41 as exist in reality.

Today, I felt like being the change I wanted to see in the world, and made a fix.